### PR TITLE
Simplify construction of sparse matrices

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: stcos
 Type: Package
 Title: Space-Time Change of Support
-Version: 0.3.1
+Version: 0.3.2
 Authors@R: c(
 	person(c("Andrew", "M."), "Raim", email = "andrew.raim@gmail.com", role = c("aut", "cre")),
 	person(c("Scott", "H."), "Holan", role = c("aut", "res")),
@@ -30,6 +30,6 @@ Imports:
 LinkingTo:
     Rcpp,
     RcppArmadillo
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3
 Encoding: UTF-8
 LazyData: true

--- a/R/areal_spacetime_bisquare.R
+++ b/R/areal_spacetime_bisquare.R
@@ -190,9 +190,7 @@ areal_spacetime_bisquare = function(dom, period, knots, w_s, w_t, control = NULL
 			X_s = st_coordinates(P)
 			for (t in seq_along(period)) {
 				X = cbind(X_s, period[t])
-				out = compute_basis_spt(X, knot_mat, w_s, w_t)
-				B = sparseMatrix(i = out$ind_row + 1, j = out$ind_col + 1, x = out$values,
-					dims = out$dim)
+				B = compute_basis_spt(X, knot_mat, w_s, w_t)
 				s_j = s_j + colSums(B) / reps
 			}
 		} else if (method == "rect") {
@@ -200,9 +198,7 @@ areal_spacetime_bisquare = function(dom, period, knots, w_s, w_t, control = NULL
 			X_s = st_coordinates(grid_out$grid)
 			for (t in seq_along(period)) {
 				X = cbind(X_s, period[t])
-				out = compute_basis_spt(X, knot_mat, w_s, w_t)
-				B = sparseMatrix(i = out$ind_row + 1, j = out$ind_col + 1, x = out$values,
-					dims = out$dim)
+				B = compute_basis_spt(X, knot_mat, w_s, w_t)
 				s_j = s_j + colSums(B) * grid_out$dx * grid_out$dy / dom_area[j]
 			}
 		} else {

--- a/R/areal_spatial_bisquare.R
+++ b/R/areal_spatial_bisquare.R
@@ -172,16 +172,12 @@ areal_spatial_bisquare = function(dom, knots, w, control = NULL)
 			# in rdomain without repeating the loop there.
 			P = rdomain(reps, dom[j,], blocksize = blocksize, itmax = reps)
 			X = st_coordinates(P)
-			out = compute_basis_sp(X, knot_mat, w)
-			B = sparseMatrix(i = out$ind_row + 1, j = out$ind_col + 1, x = out$values,
-				dims = out$dim)
+			B = compute_basis_sp(X, knot_mat, w)
 			S[j,] = colSums(B) / reps
 		} else if (method == "rect") {
 			grid_out = make_grid(dom[j,], nx, ny)
 			X = st_coordinates(grid_out$grid)
-			out = compute_basis_sp(X, knot_mat, w)
-			B = sparseMatrix(i = out$ind_row + 1, j = out$ind_col + 1, x = out$values,
-				dims = out$dim)
+			B = compute_basis_sp(X, knot_mat, w)
 			S[j,] = colSums(B) * grid_out$dx * grid_out$dy / dom_area[j]
 		} else {
 			stop("Unrecongnized method. Use `mc` or 'rect'")

--- a/R/spacetime_bisquare.R
+++ b/R/spacetime_bisquare.R
@@ -84,7 +84,5 @@
 spacetime_bisquare = function(dom, knots, w_s, w_t)
 {
 	prep = prepare_bisquare(dom, knots, type = "point")
-	out = compute_basis_spt(prep$X, prep$knot_mat, w_s, w_t)
-	sparseMatrix(i = out$ind_row + 1, j = out$ind_col + 1, x = out$values,
-		dims = out$dim)
+	compute_basis_spt(prep$X, prep$knot_mat, w_s, w_t)
 }

--- a/R/spatial_bisquare.R
+++ b/R/spatial_bisquare.R
@@ -79,7 +79,5 @@
 spatial_bisquare = function(dom, knots, w)
 {
 	prep = prepare_bisquare(dom, knots, type = "point")
-	out = compute_basis_sp(prep$X, prep$knot_mat, w)
-	sparseMatrix(i = out$ind_row + 1, j = out$ind_col + 1, x = out$values,
-		dims = out$dim)
+	compute_basis_sp(prep$X, prep$knot_mat, w)
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -12,26 +12,26 @@ Rcpp::Rostream<false>& Rcpp::Rcerr = Rcpp::Rcpp_cerr_get();
 #endif
 
 // compute_basis_sp
-Rcpp::List compute_basis_sp(const Rcpp::NumericMatrix& X, const Rcpp::NumericMatrix& cc, double w);
+arma::sp_mat compute_basis_sp(const arma::mat& X, const arma::mat& cc, double w);
 RcppExport SEXP _stcos_compute_basis_sp(SEXP XSEXP, SEXP ccSEXP, SEXP wSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< const Rcpp::NumericMatrix& >::type X(XSEXP);
-    Rcpp::traits::input_parameter< const Rcpp::NumericMatrix& >::type cc(ccSEXP);
+    Rcpp::traits::input_parameter< const arma::mat& >::type X(XSEXP);
+    Rcpp::traits::input_parameter< const arma::mat& >::type cc(ccSEXP);
     Rcpp::traits::input_parameter< double >::type w(wSEXP);
     rcpp_result_gen = Rcpp::wrap(compute_basis_sp(X, cc, w));
     return rcpp_result_gen;
 END_RCPP
 }
 // compute_basis_spt
-Rcpp::List compute_basis_spt(const Rcpp::NumericMatrix& X, const Rcpp::NumericMatrix& cc, double w_s, double w_t);
+arma::sp_mat compute_basis_spt(const arma::mat& X, const arma::mat& cc, double w_s, double w_t);
 RcppExport SEXP _stcos_compute_basis_spt(SEXP XSEXP, SEXP ccSEXP, SEXP w_sSEXP, SEXP w_tSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< const Rcpp::NumericMatrix& >::type X(XSEXP);
-    Rcpp::traits::input_parameter< const Rcpp::NumericMatrix& >::type cc(ccSEXP);
+    Rcpp::traits::input_parameter< const arma::mat& >::type X(XSEXP);
+    Rcpp::traits::input_parameter< const arma::mat& >::type cc(ccSEXP);
     Rcpp::traits::input_parameter< double >::type w_s(w_sSEXP);
     Rcpp::traits::input_parameter< double >::type w_t(w_tSEXP);
     rcpp_result_gen = Rcpp::wrap(compute_basis_spt(X, cc, w_s, w_t));

--- a/src/bisquare_basis.cpp
+++ b/src/bisquare_basis.cpp
@@ -1,19 +1,11 @@
-#include <Rcpp.h>
+#include <RcppArmadillo.h>
 #include <vector>
 
-/*
- * Note: Rcpp Vectors can be used directly for ind_row, ind_col, and vals,
- * but their capacity management seemed to be inefficient when doing many
- * push_backs. This may have been an issue with something in my setup,
- * and not necessarily Rcpp...
- */
-
 // [[Rcpp::export]]
-Rcpp::List compute_basis_sp(const Rcpp::NumericMatrix& X,
-	const Rcpp::NumericMatrix& cc, double w)
+arma::sp_mat compute_basis_sp(const arma::mat& X, const arma::mat& cc, double w)
 {
-	unsigned int N = X.rows();
-	unsigned int r = cc.rows();
+	unsigned int N = X.n_rows;
+	unsigned int r = cc.n_rows;
 
 	std::vector<unsigned int> ind_row;
 	std::vector<unsigned int> ind_col;
@@ -39,21 +31,21 @@ Rcpp::List compute_basis_sp(const Rcpp::NumericMatrix& X,
 		}
 	}
 
-	// Sparse representation of result
-	return Rcpp::List::create(
-		Rcpp::Named("ind_row") = ind_row,
-		Rcpp::Named("ind_col") = ind_col,
-		Rcpp::Named("values") = vals,
-		Rcpp::Named("dim") = Rcpp::NumericVector::create(N,r)
-	);
+	// Batch insertion constructor for sparse matrix
+	arma::umat loc(2, vals.size());
+	loc.row(0) = arma::conv_to<arma::urowvec>::from(ind_row);
+	loc.row(1) = arma::conv_to<arma::urowvec>::from(ind_col);
+	arma::sp_mat out(loc, arma::vec(vals), N, r);
+
+	return out;
 }
 
 // [[Rcpp::export]]
-Rcpp::List compute_basis_spt(const Rcpp::NumericMatrix& X,
-	const Rcpp::NumericMatrix& cc, double w_s, double w_t)
+arma::sp_mat compute_basis_spt(const arma::mat& X, const arma::mat& cc,
+	double w_s, double w_t)
 {
-	unsigned int N = X.rows();
-	unsigned int r = cc.rows();
+	unsigned int N = X.n_rows;
+	unsigned int r = cc.n_rows;
 
 	std::vector<unsigned int> ind_row;
 	std::vector<unsigned int> ind_col;
@@ -83,11 +75,11 @@ Rcpp::List compute_basis_spt(const Rcpp::NumericMatrix& X,
 		}
 	}
 
-	// Sparse representation of result
-	return Rcpp::List::create(
-		Rcpp::Named("ind_row") = ind_row,
-		Rcpp::Named("ind_col") = ind_col,
-		Rcpp::Named("values") = vals,
-		Rcpp::Named("dim") = Rcpp::NumericVector::create(N,r)
-	);
+	// Batch insertion constructor for sparse matrix
+	arma::umat loc(2, vals.size());
+	loc.row(0) = arma::conv_to<arma::urowvec>::from(ind_row);
+	loc.row(1) = arma::conv_to<arma::urowvec>::from(ind_col);
+	arma::sp_mat out(loc, arma::vec(vals), N, r);
+
+	return out;
 }


### PR DESCRIPTION
Use arma batch insertion to construct sparse matrix in C++, rather than returning Rcpp List and  immediately converting to a sparse matrix in R. Performance is about the same but the code is simpler.